### PR TITLE
Remove unused dependencies from classpath

### DIFF
--- a/kamel-core/build.gradle.kts
+++ b/kamel-core/build.gradle.kts
@@ -22,7 +22,6 @@ kotlin {
                 api(compose.foundation)
                 api(compose.runtime)
                 api(Dependencies.Ktor.Core)
-                api(Dependencies.Ktor.Logging)
             }
         }
 

--- a/kamel-image/build.gradle.kts
+++ b/kamel-image/build.gradle.kts
@@ -74,26 +74,17 @@ kotlin {
             }
         }
 
-        val desktopMain by getting {
-            dependencies {
-                implementation(Dependencies.Ktor.CIO)
-            }
-        }
+        val desktopMain by getting
 
         val desktopTest by getting {
             dependencies {
+                implementation(Dependencies.Ktor.CIO)
                 implementation(compose.desktop.currentOs)
                 implementation(kotlin("test-junit"))
             }
         }
 
-        val androidMain by getting {
-            dependencies {
-                implementation(Dependencies.Ktor.Android)
-                implementation(Dependencies.Android.Appcompat)
-                implementation(Dependencies.Android.Core)
-            }
-        }
+        val androidMain by getting
 
         val androidTest by getting {
             dependencies {

--- a/kamel-samples/build.gradle.kts
+++ b/kamel-samples/build.gradle.kts
@@ -82,12 +82,14 @@ kotlin {
                 implementation(Dependencies.Android.Core)
                 implementation(Dependencies.Android.ActivityCompose)
                 implementation(Dependencies.Android.Material)
+                implementation(Dependencies.Ktor.Android)
             }
         }
 
         val desktopMain by getting {
             dependencies {
                 implementation(compose.desktop.currentOs)
+                implementation(Dependencies.Ktor.CIO)
             }
         }
 


### PR DESCRIPTION
I noticed that some weird/oudated dependcencies were showing up in my classpath like Ktor CIO and Ktor Android clients. I use OkHttp as my ktor backend. Since Kamel is a library its not supposed to implement things like Ktor Logging and CIO or other ktor client backends and leave that to the user. 

I cleaned up any other unneeded depencencies I found in the files.